### PR TITLE
API Extension, and test provision.

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -33,7 +33,7 @@ class Parser
     ];
 
     /** @var array */
-    private $parsedCommands;
+    private $parsedCommands = [];
 
     /**
      * Check if parsed parameters has param.
@@ -221,4 +221,14 @@ class Parser
 
         return $this->stripSlashes($argument);
     }
+
+    /**
+     *
+     * @return array
+     */
+    public function getParsedCommands(): array
+    {
+        return $this->parsedCommands;
+    }
+
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -68,6 +68,44 @@ class ParserTest extends TestCase
         $this->assertEquals($expect, $this->parser->getBoolean($params['key'], $params['default']));
     }
 
+    public function testGetParsedCommands_shouldReturnAnEmptyArrayIfObjectIsFresh()
+    {
+        $parser = new Parser();
+        $this->assertEmpty(
+            $parser->getParsedCommands(),
+            "It's expected to receive an empty array if no parsing has been done yet."
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider parseProvider
+     *
+     * @param array $params
+     * @param array $expect
+     */
+    public function testGetParsedCommands_shouldReturnParsedCommand(array $params, array $expect)
+    {
+        $this->parser->parse($params["command"]);
+        $this->assertEquals(
+            $expect,
+            $this->parser->getParsedCommands(),
+            "Parsed commands should be returned."
+        );
+        $this->parser->parse(["script-with-no-parameters"]);
+        $this->assertEmpty(
+            $this->parser->getParsedCommands(),
+            "Parser state should be modified absolutely, if overridden by another parse call."
+        );
+
+        $this->parser->parse($params["command"]);
+        $this->assertEquals(
+            $expect,
+            $this->parser->getParsedCommands(),
+            "Parsed commands should be returned after re-parsing original command."
+        );
+    }
+
     public function parseProvider()
     {
         return include __DIR__ . '/fixtures/parse_parameters.php';

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -13,6 +13,7 @@ namespace Phalcon\Cop\Tests;
 
 use Phalcon\Cop\Parser;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 /**
  * Phalcon\Cop\Tests\ParserTest
@@ -104,6 +105,84 @@ class ParserTest extends TestCase
             $this->parser->getParsedCommands(),
             "Parsed commands should be returned after re-parsing original command."
         );
+    }
+
+    /**
+     * @test
+     * @dataProvider parseProvider
+     *
+     * @param array $params
+     * @param array $expect
+     */
+    public function testGet_returnsBoundDefaultValueIfValueNotSet(array $params, array $expect)
+    {
+        $expectedDefaultValues = [
+            123,
+            "test",
+            12.3,
+            true,
+            new stdClass()
+        ];
+        $nonExistingParameterKey = "non-existing-parameter-key";
+
+        foreach ($expectedDefaultValues as $expectedDefaultValue) {
+            $this->assertEquals(
+                $expectedDefaultValue,
+                $this->parser->get($nonExistingParameterKey, $expectedDefaultValue),
+                "Should return the provided default value, if the queried parameter doesn't exist in an empty/fresh object."
+            );
+        }
+
+        $this->parser->parse($params["command"]);
+
+        foreach ($expectedDefaultValues as $expectedDefaultValue) {
+            $this->assertEquals(
+                $expectedDefaultValue,
+                $this->parser->get($nonExistingParameterKey, $expectedDefaultValue),
+                "Should return null, if the queried parameter doesn't exist in a populated/parsed object."
+            );
+        }
+    }
+
+    /**
+     * @test
+     * @dataProvider parseProvider
+     *
+     * @param array $params
+     * @param array $expect
+     */
+    public function testGet_returnsNullIfParamDoesNotExist(array $params, array $expect)
+    {
+        $nonExistingParameterKey = "non-existing-parameter-key";
+        $this->assertNull(
+            $this->parser->get($nonExistingParameterKey),
+            "Should return null, if the queried parameter doesn't exist in an empty/fresh object."
+        );
+
+        $this->parser->parse($params["command"]);
+        $this->assertNull(
+            $this->parser->get($nonExistingParameterKey),
+            "Should return null, if the queried parameter doesn't exist in a populated/parsed object."
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider parseProvider
+     *
+     * @param array $params
+     * @param array $expect
+     */
+    public function testGet_returnsValueIfParamDoesExist(array $params, array $expect)
+    {
+        $this->parser->parse($params["command"]);
+        foreach ($expect as $parameterKey => $expectedValue) {
+            $this->assertEquals(
+                $expectedValue,
+                $this->parser->get($parameterKey),
+                "It's expected to have the value returned untouched."
+            );
+        }
     }
 
     public function parseProvider()


### PR DESCRIPTION
I needed an API extension so that I can access the whole map/array for further processing, and have also provided tests for the existing `get` method.

It would be great if a release could be done, as currently according to the tagging, version `1.1.0` is the freshest, and it also lacks the simple get method.

I hope this PR is helpful.